### PR TITLE
feat(export): add --from and --to date range filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,9 @@ Export report data as text, CSV, or JSON.
 tock export --today                             # Export today's report as a text file
 tock export --yesterday --format csv           # Export yesterday's report as CSV
 tock export --date 2026-01-29 --fmt json       # Export a specific day as JSON
+tock export --from 2026-04-01 --to 2026-04-15  # Export date range
+tock export --from 2026-04-01                  # Export from date to present
+tock export --to 2026-04-15                    # Export all activities up to date
 tock export -p "Work" -d "meeting" -m csv      # Export filtered activities as CSV
 tock export --today --stdout                   # Print the export to stdout
 tock export --today -o ./exports               # Write the export file to a specific directory
@@ -692,6 +695,8 @@ tock export --today -o ./exports               # Write the export file to a spec
 - `--today`: Export data for today
 - `--yesterday`: Export data for yesterday
 - `--date`: Export data for a specific date (YYYY-MM-DD)
+- `--from`: Start date for export range (YYYY-MM-DD)
+- `--to`: End date for export range (YYYY-MM-DD)
 - `-p, --project`: Filter by project
 - `-d, --description`: Filter by description
 - `-m, --format`: Export format: `txt`, `csv`, or `json` (default `txt`)

--- a/internal/app/commands/export.go
+++ b/internal/app/commands/export.go
@@ -12,6 +12,7 @@ import (
 
 	exportapp "github.com/kriuchkov/tock/internal/app/export"
 	"github.com/kriuchkov/tock/internal/core/models"
+	"github.com/kriuchkov/tock/internal/timeutil"
 )
 
 type exportOptions struct {

--- a/internal/app/commands/export.go
+++ b/internal/app/commands/export.go
@@ -15,14 +15,16 @@ import (
 )
 
 type exportOptions struct {
-	Today       bool
-	Yesterday   bool
-	Date        string
-	Project     string
-	Description string
-	Format      string
-	Path        string
-	Stdout      bool
+        Today       bool
+        Yesterday   bool
+        Date        string
+        Project     string
+        Description string
+        Format      string
+        Path        string
+        Stdout      bool
+        From        string
+        To          string
 }
 
 func NewExportCmd() *cobra.Command {
@@ -45,10 +47,46 @@ func NewExportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opt.Format, "fmt", "txt", defaultText("export.flag.format"))
 	cmd.Flags().StringVarP(&opt.Path, "path", "o", "", defaultText("export.flag.path"))
 	cmd.Flags().BoolVar(&opt.Stdout, "stdout", false, defaultText("export.flag.stdout"))
+        cmd.Flags().StringVar(&opt.From, "from", "", "Start date for export range (YYYY-MM-DD)")
+        cmd.Flags().StringVar(&opt.To, "to", "", "End date for export range (YYYY-MM-DD)")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", projectRegisterFlagCompletion)
 	_ = cmd.RegisterFlagCompletionFunc("description", descriptionRegisterFlagCompletion)
 	return cmd
+}
+
+func validateExportFlags(opt *exportOptions) error {
+        dateFlags := 0
+        if opt.Today {
+                dateFlags++
+        }
+        if opt.Yesterday {
+                dateFlags++
+        }
+        if opt.Date != "" {
+                dateFlags++
+        }
+        if opt.From != "" || opt.To != "" {
+                dateFlags++
+        }
+
+        if dateFlags > 1 {
+                return errors.New("cannot specify multiple date filters (--today, --yesterday, --date, --from/--to are mutually exclusive)")
+        }
+
+        if opt.From != "" {
+                if _, err := time.Parse("2006-01-02", opt.From); err != nil {
+                        return errors.Wrap(err, "invalid --from date format, use YYYY-MM-DD")
+                }
+        }
+
+        if opt.To != "" {
+                if _, err := time.Parse("2006-01-02", opt.To); err != nil {
+                        return errors.Wrap(err, "invalid --to date format, use YYYY-MM-DD")
+                }
+        }
+
+        return nil
 }
 
 func runExportCmd(cmd *cobra.Command, opt *exportOptions) error {

--- a/internal/app/commands/export.go
+++ b/internal/app/commands/export.go
@@ -96,14 +96,29 @@ func runExportCmd(cmd *cobra.Command, opt *exportOptions) error {
 	if err := validateExportFlags(opt); err != nil {
 		return err
 	}
-	filter, err := models.BuildActivityFilter(models.ActivityFilterOptions{
-		Now:         time.Now(),
-		Today:       opt.Today,
-		Yesterday:   opt.Yesterday,
-		Date:        opt.Date,
-		Project:     opt.Project,
-		Description: opt.Description,
-	})
+
+	var fromDate, toDate *time.Time
+    if opt.From != "" {
+        t, _ := time.ParseInLocation("2006-01-02", opt.From, time.Local)
+        fromDate = &t
+    }
+    if opt.To != "" {
+        t, _ := time.ParseInLocation("2006-01-02", opt.To, time.Local)
+        _, end := timeutil.LocalDayBounds(t)
+        toDate = &end
+    }
+
+    filter, err := models.BuildActivityFilter(models.ActivityFilterOptions{
+        Now:         time.Now(),
+        Today:       opt.Today,
+        Yesterday:   opt.Yesterday,
+        Date:        opt.Date,
+        FromDate:    fromDate,
+        ToDate:      toDate,
+        Project:     opt.Project,
+        Description: opt.Description,
+    })
+
 	if err != nil {
 		return errors.Wrap(err, "build activity filter")
 	}

--- a/internal/app/commands/export.go
+++ b/internal/app/commands/export.go
@@ -15,16 +15,16 @@ import (
 )
 
 type exportOptions struct {
-        Today       bool
-        Yesterday   bool
-        Date        string
-        Project     string
-        Description string
-        Format      string
-        Path        string
-        Stdout      bool
-        From        string
-        To          string
+	Today       bool
+	Yesterday   bool
+	Date        string
+	Project     string
+	Description string
+	Format      string
+	Path        string
+	Stdout      bool
+	From        string
+	To          string
 }
 
 func NewExportCmd() *cobra.Command {
@@ -47,8 +47,8 @@ func NewExportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opt.Format, "fmt", "txt", defaultText("export.flag.format"))
 	cmd.Flags().StringVarP(&opt.Path, "path", "o", "", defaultText("export.flag.path"))
 	cmd.Flags().BoolVar(&opt.Stdout, "stdout", false, defaultText("export.flag.stdout"))
-        cmd.Flags().StringVar(&opt.From, "from", "", "Start date for export range (YYYY-MM-DD)")
-        cmd.Flags().StringVar(&opt.To, "to", "", "End date for export range (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&opt.From, "from", "", "Start date for export range (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&opt.To, "to", "", "End date for export range (YYYY-MM-DD)")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", projectRegisterFlagCompletion)
 	_ = cmd.RegisterFlagCompletionFunc("description", descriptionRegisterFlagCompletion)
@@ -56,43 +56,46 @@ func NewExportCmd() *cobra.Command {
 }
 
 func validateExportFlags(opt *exportOptions) error {
-        dateFlags := 0
-        if opt.Today {
-                dateFlags++
-        }
-        if opt.Yesterday {
-                dateFlags++
-        }
-        if opt.Date != "" {
-                dateFlags++
-        }
-        if opt.From != "" || opt.To != "" {
-                dateFlags++
-        }
+	dateFlags := 0
+	if opt.Today {
+		dateFlags++
+	}
+	if opt.Yesterday {
+		dateFlags++
+	}
+	if opt.Date != "" {
+		dateFlags++
+	}
+	if opt.From != "" || opt.To != "" {
+		dateFlags++
+	}
 
-        if dateFlags > 1 {
-                return errors.New("cannot specify multiple date filters (--today, --yesterday, --date, --from/--to are mutually exclusive)")
-        }
+	if dateFlags > 1 {
+		return errors.New("cannot specify multiple date filters (--today, --yesterday, --date, --from/--to are mutually exclusive)")
+	}
 
-        if opt.From != "" {
-                if _, err := time.Parse("2006-01-02", opt.From); err != nil {
-                        return errors.Wrap(err, "invalid --from date format, use YYYY-MM-DD")
-                }
-        }
+	if opt.From != "" {
+		if _, err := time.Parse("2006-01-02", opt.From); err != nil {
+			return errors.Wrap(err, "invalid --from date format, use YYYY-MM-DD")
+		}
+	}
 
-        if opt.To != "" {
-                if _, err := time.Parse("2006-01-02", opt.To); err != nil {
-                        return errors.Wrap(err, "invalid --to date format, use YYYY-MM-DD")
-                }
-        }
+	if opt.To != "" {
+		if _, err := time.Parse("2006-01-02", opt.To); err != nil {
+			return errors.Wrap(err, "invalid --to date format, use YYYY-MM-DD")
+		}
+	}
 
-        return nil
+	return nil
 }
 
 func runExportCmd(cmd *cobra.Command, opt *exportOptions) error {
 	rt := getRuntime(cmd)
 	out := cmd.OutOrStdout()
 
+	if err := validateExportFlags(opt); err != nil {
+		return err
+	}
 	filter, err := models.BuildActivityFilter(models.ActivityFilterOptions{
 		Now:         time.Now(),
 		Today:       opt.Today,

--- a/internal/app/commands/export.go
+++ b/internal/app/commands/export.go
@@ -75,13 +75,13 @@ func validateExportFlags(opt *exportOptions) error {
 	}
 
 	if opt.From != "" {
-		if _, err := time.Parse("2006-01-02", opt.From); err != nil {
+		if _, err := time.ParseInLocation("2006-01-02", opt.From, time.Local); err != nil {
 			return errors.Wrap(err, "invalid --from date format, use YYYY-MM-DD")
 		}
 	}
 
 	if opt.To != "" {
-		if _, err := time.Parse("2006-01-02", opt.To); err != nil {
+		if _, err := time.ParseInLocation("2006-01-02", opt.To, time.Local); err != nil {
 			return errors.Wrap(err, "invalid --to date format, use YYYY-MM-DD")
 		}
 	}

--- a/internal/app/commands/export.go
+++ b/internal/app/commands/export.go
@@ -99,26 +99,26 @@ func runExportCmd(cmd *cobra.Command, opt *exportOptions) error {
 	}
 
 	var fromDate, toDate *time.Time
-    if opt.From != "" {
-        t, _ := time.ParseInLocation("2006-01-02", opt.From, time.Local)
-        fromDate = &t
-    }
-    if opt.To != "" {
-        t, _ := time.ParseInLocation("2006-01-02", opt.To, time.Local)
-        _, end := timeutil.LocalDayBounds(t)
-        toDate = &end
-    }
+	if opt.From != "" {
+		t, _ := time.ParseInLocation("2006-01-02", opt.From, time.Local)
+		fromDate = &t
+	}
+	if opt.To != "" {
+		t, _ := time.ParseInLocation("2006-01-02", opt.To, time.Local)
+		_, end := timeutil.LocalDayBounds(t)
+		toDate = &end
+	}
 
-    filter, err := models.BuildActivityFilter(models.ActivityFilterOptions{
-        Now:         time.Now(),
-        Today:       opt.Today,
-        Yesterday:   opt.Yesterday,
-        Date:        opt.Date,
-        FromDate:    fromDate,
-        ToDate:      toDate,
-        Project:     opt.Project,
-        Description: opt.Description,
-    })
+	filter, err := models.BuildActivityFilter(models.ActivityFilterOptions{
+		Now:         time.Now(),
+		Today:       opt.Today,
+		Yesterday:   opt.Yesterday,
+		Date:        opt.Date,
+		FromDate:    fromDate,
+		ToDate:      toDate,
+		Project:     opt.Project,
+		Description: opt.Description,
+	})
 
 	if err != nil {
 		return errors.Wrap(err, "build activity filter")

--- a/internal/app/commands/export_test.go
+++ b/internal/app/commands/export_test.go
@@ -81,47 +81,47 @@ func TestRuntimeDefaultExportDirUsesTimewarriorErrorForEmptyPath(t *testing.T) {
 }
 
 func TestValidateExportFlags(t *testing.T) {
-    tests := []struct {
-        name    string
-        opt     exportOptions
-        wantErr string
-    }{
-        {
-            name:    "from and today are mutually exclusive",
-            opt:     exportOptions{From: "2026-04-01", Today: true},
-            wantErr: "cannot specify multiple date filters",
-        },
-        {
-            name:    "invalid from date",
-            opt:     exportOptions{From: "not-a-date"},
-            wantErr: "invalid --from date format",
-        },
-        {
-            name:    "invalid to date",
-            opt:     exportOptions{To: "2026-13-01"},
-            wantErr: "invalid --to date format",
-        },
-        {
-            name: "from only is valid",
-            opt:  exportOptions{From: "2026-04-01"},
-        },
-        {
-            name: "to only is valid",
-            opt:  exportOptions{To: "2026-04-15"},
-        },
-        {
-            name: "from and to together are valid",
-            opt:  exportOptions{From: "2026-04-01", To: "2026-04-15"},
-        },
-    }
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            err := validateExportFlags(&tt.opt)
-            if tt.wantErr != "" {
-                require.ErrorContains(t, err, tt.wantErr)
-            } else {
-                require.NoError(t, err)
-            }
-        })
-    }
+	tests := []struct {
+		name    string
+		opt     exportOptions
+		wantErr string
+	}{
+		{
+			name:    "from and today are mutually exclusive",
+			opt:     exportOptions{From: "2026-04-01", Today: true},
+			wantErr: "cannot specify multiple date filters",
+		},
+		{
+			name:    "invalid from date",
+			opt:     exportOptions{From: "not-a-date"},
+			wantErr: "invalid --from date format",
+		},
+		{
+			name:    "invalid to date",
+			opt:     exportOptions{To: "2026-13-01"},
+			wantErr: "invalid --to date format",
+		},
+		{
+			name: "from only is valid",
+			opt:  exportOptions{From: "2026-04-01"},
+		},
+		{
+			name: "to only is valid",
+			opt:  exportOptions{To: "2026-04-15"},
+		},
+		{
+			name: "from and to together are valid",
+			opt:  exportOptions{From: "2026-04-01", To: "2026-04-15"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExportFlags(&tt.opt)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/app/commands/export_test.go
+++ b/internal/app/commands/export_test.go
@@ -79,3 +79,49 @@ func TestRuntimeDefaultExportDirUsesTimewarriorErrorForEmptyPath(t *testing.T) {
 	assert.Empty(t, dir)
 	require.EqualError(t, err, "timewarrior data path is empty")
 }
+
+func TestValidateExportFlags(t *testing.T) {
+    tests := []struct {
+        name    string
+        opt     exportOptions
+        wantErr string
+    }{
+        {
+            name:    "from and today are mutually exclusive",
+            opt:     exportOptions{From: "2026-04-01", Today: true},
+            wantErr: "cannot specify multiple date filters",
+        },
+        {
+            name:    "invalid from date",
+            opt:     exportOptions{From: "not-a-date"},
+            wantErr: "invalid --from date format",
+        },
+        {
+            name:    "invalid to date",
+            opt:     exportOptions{To: "2026-13-01"},
+            wantErr: "invalid --to date format",
+        },
+        {
+            name: "from only is valid",
+            opt:  exportOptions{From: "2026-04-01"},
+        },
+        {
+            name: "to only is valid",
+            opt:  exportOptions{To: "2026-04-15"},
+        },
+        {
+            name: "from and to together are valid",
+            opt:  exportOptions{From: "2026-04-01", To: "2026-04-15"},
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            err := validateExportFlags(&tt.opt)
+            if tt.wantErr != "" {
+                require.ErrorContains(t, err, tt.wantErr)
+            } else {
+                require.NoError(t, err)
+            }
+        })
+    }
+}

--- a/internal/core/models/activity_filter.go
+++ b/internal/core/models/activity_filter.go
@@ -20,49 +20,48 @@ type ActivityFilterOptions struct {
 }
 
 func BuildActivityFilter(opts ActivityFilterOptions) (ActivityFilter, error) {
-	now := opts.Now
-	if now.IsZero() {
-		now = time.Now()
-	}
+    now := opts.Now
+    if now.IsZero() {
+        now = time.Now()
+    }
 
-	filter := ActivityFilter{}
+    filter := ActivityFilter{}
 
-	if opts.FromDate != nil || opts.ToDate != nil {
-		if opts.FromDate != nil {
-			filter.FromDate = opts.FromDate
-		}
-		if opts.ToDate != nil {
-			filter.ToDate = opts.ToDate
-		}
-	} else {
-		switch {
-		case opts.Today:
-			start, end := timeutil.LocalDayBounds(now)
-			filter.FromDate = &start
-			filter.ToDate = &end
-		case opts.Yesterday:
-			todayStart, _ := timeutil.LocalDayBounds(now)
-			start := todayStart.AddDate(0, 0, -1)
-			end := todayStart
-			filter.FromDate = &start
-			filter.ToDate = &end
-		case opts.Date != "":
-			parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
-			if err != nil {
-				return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
-			}
-			start, end := timeutil.LocalDayBounds(parsedDate)
-			filter.FromDate = &start
-			filter.ToDate = &end
-		}
-	}
+    switch {
+    case opts.FromDate != nil || opts.ToDate != nil:
+        if opts.FromDate != nil {
+            filter.FromDate = opts.FromDate
+        }
+        if opts.ToDate != nil {
+            filter.ToDate = opts.ToDate
+        }
+    case opts.Today:
+        start, end := timeutil.LocalDayBounds(now)
+        filter.FromDate = &start
+        filter.ToDate = &end
+    case opts.Yesterday:
+        todayStart, _ := timeutil.LocalDayBounds(now)
+        start := todayStart.AddDate(0, 0, -1)
+        end := todayStart
+        filter.FromDate = &start
+        filter.ToDate = &end
+    case opts.Date != "":
+        parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
+        if err != nil {
+            return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
+        }
+        start, end := timeutil.LocalDayBounds(parsedDate)
+        filter.FromDate = &start
+        filter.ToDate = &end
+    }
 
-	if opts.Project != "" {
-		filter.Project = &opts.Project
-	}
-	if opts.Description != "" {
-		filter.Description = &opts.Description
-	}
+    if opts.Project != "" {
+        filter.Project = &opts.Project
+    }
+    if opts.Description != "" {
+        filter.Description = &opts.Description
+    }
 
-	return filter, nil
+    return filter, nil
 }
+

--- a/internal/core/models/activity_filter.go
+++ b/internal/core/models/activity_filter.go
@@ -1,69 +1,68 @@
 package models
 
 import (
-        "time"
+	"time"
 
-        "github.com/go-faster/errors"
+	"github.com/go-faster/errors"
 
-        "github.com/kriuchkov/tock/internal/timeutil"
+	"github.com/kriuchkov/tock/internal/timeutil"
 )
 
 type ActivityFilterOptions struct {
-        Now         time.Time
-        Today       bool
-        Yesterday   bool
-        Date        string
-        FromDate    *time.Time
-        ToDate      *time.Time
-        Project     string
-        Description string
+	Now         time.Time
+	Today       bool
+	Yesterday   bool
+	Date        string
+	FromDate    *time.Time
+	ToDate      *time.Time
+	Project     string
+	Description string
 }
 
 func BuildActivityFilter(opts ActivityFilterOptions) (ActivityFilter, error) {
-        now := opts.Now
-        if now.IsZero() {
-                now = time.Now()
-        }
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
 
-        filter := ActivityFilter{}
+	filter := ActivityFilter{}
 
-        if opts.FromDate != nil || opts.ToDate != nil {
-                if opts.FromDate != nil {
-                        filter.FromDate = opts.FromDate
-                }
-                if opts.ToDate != nil {
-                        filter.ToDate = opts.ToDate
-                }
-        } else {
-                switch {
-                case opts.Today:
-                        start, end := timeutil.LocalDayBounds(now)
-                        filter.FromDate = &start
-                        filter.ToDate = &end
-                case opts.Yesterday:
-                        todayStart, _ := timeutil.LocalDayBounds(now)
-                        start := todayStart.AddDate(0, 0, -1)
-                        end := todayStart
-                        filter.FromDate = &start
-                        filter.ToDate = &end
-                case opts.Date != "":
-                        parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
-                        if err != nil {
-                                return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
-                        }
-                        start, end := timeutil.LocalDayBounds(parsedDate)
-                        filter.FromDate = &start
-                        filter.ToDate = &end
-                }
-        }
+	if opts.FromDate != nil || opts.ToDate != nil {
+		if opts.FromDate != nil {
+			filter.FromDate = opts.FromDate
+		}
+		if opts.ToDate != nil {
+			filter.ToDate = opts.ToDate
+		}
+	} else {
+		switch {
+		case opts.Today:
+			start, end := timeutil.LocalDayBounds(now)
+			filter.FromDate = &start
+			filter.ToDate = &end
+		case opts.Yesterday:
+			todayStart, _ := timeutil.LocalDayBounds(now)
+			start := todayStart.AddDate(0, 0, -1)
+			end := todayStart
+			filter.FromDate = &start
+			filter.ToDate = &end
+		case opts.Date != "":
+			parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
+			if err != nil {
+				return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
+			}
+			start, end := timeutil.LocalDayBounds(parsedDate)
+			filter.FromDate = &start
+			filter.ToDate = &end
+		}
+	}
 
-        if opts.Project != "" {
-                filter.Project = &opts.Project
-        }
-        if opts.Description != "" {
-                filter.Description = &opts.Description
-        }
+	if opts.Project != "" {
+		filter.Project = &opts.Project
+	}
+	if opts.Description != "" {
+		filter.Description = &opts.Description
+	}
 
-        return filter, nil
+	return filter, nil
 }
-

--- a/internal/core/models/activity_filter.go
+++ b/internal/core/models/activity_filter.go
@@ -20,48 +20,47 @@ type ActivityFilterOptions struct {
 }
 
 func BuildActivityFilter(opts ActivityFilterOptions) (ActivityFilter, error) {
-    now := opts.Now
-    if now.IsZero() {
-        now = time.Now()
-    }
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
 
-    filter := ActivityFilter{}
+	filter := ActivityFilter{}
 
-    switch {
-    case opts.FromDate != nil || opts.ToDate != nil:
-        if opts.FromDate != nil {
-            filter.FromDate = opts.FromDate
-        }
-        if opts.ToDate != nil {
-            filter.ToDate = opts.ToDate
-        }
-    case opts.Today:
-        start, end := timeutil.LocalDayBounds(now)
-        filter.FromDate = &start
-        filter.ToDate = &end
-    case opts.Yesterday:
-        todayStart, _ := timeutil.LocalDayBounds(now)
-        start := todayStart.AddDate(0, 0, -1)
-        end := todayStart
-        filter.FromDate = &start
-        filter.ToDate = &end
-    case opts.Date != "":
-        parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
-        if err != nil {
-            return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
-        }
-        start, end := timeutil.LocalDayBounds(parsedDate)
-        filter.FromDate = &start
-        filter.ToDate = &end
-    }
+	switch {
+	case opts.FromDate != nil || opts.ToDate != nil:
+		if opts.FromDate != nil {
+			filter.FromDate = opts.FromDate
+		}
+		if opts.ToDate != nil {
+			filter.ToDate = opts.ToDate
+		}
+	case opts.Today:
+		start, end := timeutil.LocalDayBounds(now)
+		filter.FromDate = &start
+		filter.ToDate = &end
+	case opts.Yesterday:
+		todayStart, _ := timeutil.LocalDayBounds(now)
+		start := todayStart.AddDate(0, 0, -1)
+		end := todayStart
+		filter.FromDate = &start
+		filter.ToDate = &end
+	case opts.Date != "":
+		parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
+		if err != nil {
+			return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
+		}
+		start, end := timeutil.LocalDayBounds(parsedDate)
+		filter.FromDate = &start
+		filter.ToDate = &end
+	}
 
-    if opts.Project != "" {
-        filter.Project = &opts.Project
-    }
-    if opts.Description != "" {
-        filter.Description = &opts.Description
-    }
+	if opts.Project != "" {
+		filter.Project = &opts.Project
+	}
+	if opts.Description != "" {
+		filter.Description = &opts.Description
+	}
 
-    return filter, nil
+	return filter, nil
 }
-

--- a/internal/core/models/activity_filter.go
+++ b/internal/core/models/activity_filter.go
@@ -1,57 +1,69 @@
 package models
 
 import (
-	"time"
+        "time"
 
-	"github.com/go-faster/errors"
+        "github.com/go-faster/errors"
 
-	"github.com/kriuchkov/tock/internal/timeutil"
+        "github.com/kriuchkov/tock/internal/timeutil"
 )
 
 type ActivityFilterOptions struct {
-	Now         time.Time
-	Today       bool
-	Yesterday   bool
-	Date        string
-	Project     string
-	Description string
+        Now         time.Time
+        Today       bool
+        Yesterday   bool
+        Date        string
+        FromDate    *time.Time
+        ToDate      *time.Time
+        Project     string
+        Description string
 }
 
 func BuildActivityFilter(opts ActivityFilterOptions) (ActivityFilter, error) {
-	now := opts.Now
-	if now.IsZero() {
-		now = time.Now()
-	}
+        now := opts.Now
+        if now.IsZero() {
+                now = time.Now()
+        }
 
-	filter := ActivityFilter{}
+        filter := ActivityFilter{}
 
-	switch {
-	case opts.Today:
-		start, end := timeutil.LocalDayBounds(now)
-		filter.FromDate = &start
-		filter.ToDate = &end
-	case opts.Yesterday:
-		todayStart, _ := timeutil.LocalDayBounds(now)
-		start := todayStart.AddDate(0, 0, -1)
-		end := todayStart
-		filter.FromDate = &start
-		filter.ToDate = &end
-	case opts.Date != "":
-		parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
-		if err != nil {
-			return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
-		}
-		start, end := timeutil.LocalDayBounds(parsedDate)
-		filter.FromDate = &start
-		filter.ToDate = &end
-	}
+        if opts.FromDate != nil || opts.ToDate != nil {
+                if opts.FromDate != nil {
+                        filter.FromDate = opts.FromDate
+                }
+                if opts.ToDate != nil {
+                        filter.ToDate = opts.ToDate
+                }
+        } else {
+                switch {
+                case opts.Today:
+                        start, end := timeutil.LocalDayBounds(now)
+                        filter.FromDate = &start
+                        filter.ToDate = &end
+                case opts.Yesterday:
+                        todayStart, _ := timeutil.LocalDayBounds(now)
+                        start := todayStart.AddDate(0, 0, -1)
+                        end := todayStart
+                        filter.FromDate = &start
+                        filter.ToDate = &end
+                case opts.Date != "":
+                        parsedDate, err := time.ParseInLocation("2006-01-02", opts.Date, time.Local)
+                        if err != nil {
+                                return ActivityFilter{}, errors.Wrap(err, "invalid date format (use YYYY-MM-DD)")
+                        }
+                        start, end := timeutil.LocalDayBounds(parsedDate)
+                        filter.FromDate = &start
+                        filter.ToDate = &end
+                }
+        }
 
-	if opts.Project != "" {
-		filter.Project = &opts.Project
-	}
-	if opts.Description != "" {
-		filter.Description = &opts.Description
-	}
+        if opts.Project != "" {
+                filter.Project = &opts.Project
+        }
+        if opts.Description != "" {
+                filter.Description = &opts.Description
+        }
 
-	return filter, nil
+        return filter, nil
 }
+


### PR DESCRIPTION
- Add --from flag to specify start date for export range
- Add --to flag to specify end date for export range
- Support filtering activities by date range
- Add validation to prevent conflicting date flags
- Update documentation with examples

Example usage:
  tock export --from 2026-04-01 --to 2026-04-15 tock export --from 2026-04-01 --format json tock export --to 2026-04-15 --project Work

# Description

<!-- Describe what this PR does. What problem does it solve or what feature does it add? -->

## Type of change

- [x] New feature
- [x] Documentation update

