### PR TITLE
fix(tray): ship a working menu bar in macOS releases (cgo)

### DIFF
--- a/internal/app/commands/tray_darwin.go
+++ b/internal/app/commands/tray_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package commands
 

--- a/internal/app/commands/tray_darwin_nocgo.go
+++ b/internal/app/commands/tray_darwin_nocgo.go
@@ -1,0 +1,30 @@
+//go:build darwin && !cgo
+
+package commands
+
+import (
+	"github.com/go-faster/errors"
+	"github.com/spf13/cobra"
+)
+
+// The macOS menu bar integration (fyne.io/systray) is implemented in
+// Objective-C and needs cgo, so it is compiled out of CGO-disabled builds
+// (e.g. the cross-compiled release binaries). Build from source with cgo
+// enabled — the default for `go build`/`go install` on macOS — to get it.
+
+// runTray is unavailable without cgo; the menu bar integration needs the
+// Objective-C status bar bridge.
+func runTray(cmd *cobra.Command) error {
+	return errors.New(text(cmd, "tray.needs_cgo"))
+}
+
+// ensureTrayRunning is a no-op without cgo: there is no menu bar icon to spawn.
+func ensureTrayRunning(*cobra.Command) {}
+
+func installTrayAgent(cmd *cobra.Command) error {
+	return errors.New(text(cmd, "tray.needs_cgo"))
+}
+
+func uninstallTrayAgent(cmd *cobra.Command) error {
+	return errors.New(text(cmd, "tray.needs_cgo"))
+}

--- a/internal/app/commands/tray_darwin_test.go
+++ b/internal/app/commands/tray_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package commands
 

--- a/internal/app/commands/tray_icon_darwin.go
+++ b/internal/app/commands/tray_icon_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package commands
 

--- a/internal/app/commands/tray_icon_darwin_test.go
+++ b/internal/app/commands/tray_icon_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package commands
 

--- a/internal/app/commands/tray_launchd_darwin.go
+++ b/internal/app/commands/tray_launchd_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package commands
 

--- a/internal/app/commands/tray_lifecycle_darwin.go
+++ b/internal/app/commands/tray_lifecycle_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package commands
 

--- a/internal/app/localization/langs/eng.json
+++ b/internal/app/localization/langs/eng.json
@@ -206,6 +206,7 @@
   "tray.short": "Run the macOS menu bar icon (timer, start last, stop)",
   "tray.disabled": "The menu bar icon is disabled. Enable it with 'tray.enabled: true' in your config (or TOCK_TRAY_ENABLED=1).",
   "tray.unsupported": "The menu bar icon is only supported on macOS.",
+  "tray.needs_cgo": "The menu bar icon needs a CGO-enabled build. The prebuilt release binaries are compiled without CGO; build from source (the default 'go build'/'go install' on macOS enables it).",
   "tray.running": "Menu bar icon started — look for the clock in the macOS menu bar (top-right). Press Ctrl-C here to quit.",
   "tray.already_running": "The menu bar icon is already running.",
   "tray.install.short": "Install a login agent so the menu bar icon always runs",


### PR DESCRIPTION
The prebuilt / Homebrew `tock` had the menu bar (and the sqlite backend) compiled out, so `tock tray install` reported *"The menu bar icon needs a CGO-enabled build"*. Two causes, two fixes:

## 1. Code: guard the tray behind cgo (`fix(tray)`)
`fyne.io/systray`'s macOS backend is Objective-C and needs cgo. The old cross-compiled release (CGO=0) failed to even link it (`undefined: nativeLoop`, ...). Gate the darwin tray behind `darwin && cgo` and add a `darwin && !cgo` stub (mirroring the existing non-macOS stub) so CGO-disabled builds still compile with a clear message.

## 2. Release: build darwin with cgo on macOS (`build(release)`)
Even after (1), a CGO=0 release ships a **stubbed** tray. So build the darwin binaries natively with `CGO_ENABLED=1`:
- goreleaser `release` job now runs on `macos-latest`.
- `.goreleaser.yaml` overrides the darwin targets to `CGO_ENABLED=1` (systray + go-sqlite3 compiled in); linux stays CGO-free (pure-Go cross-build from the same runner).

Result: `brew upgrade kriuchkov/tap/tock` gets a working menu bar (and a working sqlite backend) by default.

## Verification (local)
- `CGO_ENABLED=0 GOOS=darwin|linux go build` — compiles (stub) ✅
- `CGO_ENABLED=1 go build` darwin arm64 **and** amd64 (cross-arch from arm64 host) — real tray ✅
- `goreleaser build --snapshot` darwin/arm64 → `CGO_ENABLED=1`, systray symbols present (not the stub) ✅
- `go test ./...` ✅

## Note
`goreleaser check` flags two **pre-existing** deprecations (`archives.format`, `brews`→`homebrew_casks`) unrelated to this change — worth a separate cleanup PR before they break under a future goreleaser.