### PR TITLE
build(release): build darwin with cgo on macOS so brew ships the tray

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    # macOS runner so goreleaser can build the darwin binaries with cgo (the
+    # menu bar needs the Objective-C systray backend; sqlite needs go-sqlite3).
+    runs-on: macos-latest
     permissions:
       contents: write
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,18 @@ builds:
       - -X github.com/kriuchkov/tock/internal/app/commands.version={{.Version}}
       - -X github.com/kriuchkov/tock/internal/app/commands.commit={{.Commit}}
       - -X github.com/kriuchkov/tock/internal/app/commands.date={{.Date}}
+    # Build darwin natively with cgo so the menu bar (fyne.io/systray is
+    # Objective-C) and the sqlite backend (go-sqlite3) are compiled in.
+    # Requires a macOS runner. Linux stays CGO-free (pure-Go cross-build).
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CGO_ENABLED=1
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
Follow-up to #94. #94 added the code-side cgo gate, but the release still cross-compiles darwin with `CGO_ENABLED=0`, so the prebuilt / Homebrew binary ships a **stubbed** menu bar (and stubbed sqlite) — `tock tray install` reports *"needs a CGO-enabled build"*.

This builds the darwin binaries natively with cgo:
- goreleaser `release` job runs on `macos-latest`.
- `.goreleaser.yaml` overrides the darwin targets to `CGO_ENABLED=1` (fyne.io/systray Objective-C backend + go-sqlite3 compiled in); linux stays CGO-free (pure-Go cross-build from the same runner).

Result: `brew upgrade kriuchkov/tap/tock` gets a working menu bar (and sqlite) by default.

## Verification (local)
- `goreleaser build --snapshot` darwin/arm64 → binary reports `CGO_ENABLED=1` and carries systray symbols (not the stub) ✅
- `CGO_ENABLED=1 go build` for darwin **arm64 and amd64** (cross-arch amd64 links fine from an arm64 host — what the arm64 macOS runner does) ✅

Needs a real tagged release to fully confirm the runner build; low risk (single-runner, no cross-toolchain — darwin cgo is native, linux is pure Go).

## Note
`goreleaser check` flags two **pre-existing** deprecations (`archives.format`, `brews`→`homebrew_casks`) unrelated to this PR — worth a separate cleanup before a future goreleaser drops them.