### PR TITLE
build(goreleaser): use archives.formats (drop deprecated format)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - -X github.com/kriuchkov/tock/internal/app/commands.date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_


### PR DESCRIPTION
`goreleaser check` flags `archives[].format` as deprecated since v2.6. Rename to the `formats` list — mechanical, no change to the produced archives (still one `tar.gz` per target).

```diff
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
```

After this, `goreleaser check` is clean except the `brews` -> `homebrew_casks` deprecation, which is left out on purpose: it changes install UX (`brew install` -> `brew install --cask`), the tap layout (`Formula/` -> `Casks/`) and needs a `tap_migrations.json`, so it deserves its own PR/decision.

Verified: `goreleaser check` no longer reports the archives deprecation.